### PR TITLE
Fix various minor warnings from clippy

### DIFF
--- a/tm4c-hal/src/bb.rs
+++ b/tm4c-hal/src/bb.rs
@@ -9,7 +9,11 @@ use core::ptr::{read_volatile, write_volatile};
 use cortex_m::asm::nop;
 
 /// Sets/Clears a bit at the given address atomically, using the bit-banding
-/// feature. We take a const pointer and mutate it, but that's because the
+/// feature.
+///
+/// # Safety
+///
+/// We take a const pointer and mutate it, but that's because the
 /// svd2rust crate will only give us const pointers.
 pub unsafe fn change_bit<T>(address: *const T, bit: u8, value: bool) {
     let address = address as u32;
@@ -18,7 +22,11 @@ pub unsafe fn change_bit<T>(address: *const T, bit: u8, value: bool) {
 }
 
 /// Sets and then Clears a bit at the given address atomically, using the bit-
-/// banding feature. We take a const pointer and mutate it, but that's because
+/// banding feature.
+///
+/// # Safety
+///
+/// We take a const pointer and mutate it, but that's because
 /// the svd2rust crate will only give us const pointers.
 pub unsafe fn toggle_bit<T>(address: *const T, bit: u8) {
     let address = address as u32;

--- a/tm4c-hal/src/i2c.rs
+++ b/tm4c-hal/src/i2c.rs
@@ -2,6 +2,7 @@
 
 /// I2C error
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// Bus Busy
     BusBusy,
@@ -17,9 +18,6 @@ pub enum Error {
 
     /// I2C Timeout
     Timeout,
-
-    #[doc(hidden)]
-    _Extensible,
 }
 
 #[macro_export]

--- a/tm4c123x-hal/src/hib.rs
+++ b/tm4c123x-hal/src/hib.rs
@@ -67,6 +67,6 @@ impl Hib {
         let subsec: u64 = subsec.into();
 
         let millis: u64 = subsec * 1000 / 32_768;
-        return seconds * 1000 + millis;
+        seconds * 1000 + millis
     }
 }

--- a/tm4c123x-hal/src/serial.rs
+++ b/tm4c123x-hal/src/serial.rs
@@ -1,5 +1,8 @@
 //! Serial
 
+// uart_hal_macro can be called with too-many arguments
+#![allow(clippy::too_many_arguments)]
+
 pub use tm4c123x::{UART0, UART1, UART2, UART3, UART4, UART5, UART6, UART7};
 pub use tm4c_hal::{serial::*, uart_hal_macro, uart_pin_macro};
 

--- a/tm4c123x-hal/src/spi.rs
+++ b/tm4c123x-hal/src/spi.rs
@@ -15,7 +15,6 @@ use crate::{
     time::Hertz,
 };
 
-use nb;
 use tm4c123x::{SSI0, SSI1, SSI2, SSI3};
 
 /// SPI error

--- a/tm4c123x-hal/src/sysctl.rs
+++ b/tm4c123x-hal/src/sysctl.rs
@@ -39,16 +39,14 @@ pub struct Sysctl {
 }
 
 /// Used to gate access to the run-time power control features of the chip.
-pub struct PowerControl {
-    _0: (),
-}
+#[non_exhaustive]
+pub struct PowerControl {}
 
 /// Used to configure the clock generators.
+#[non_exhaustive]
 pub struct ClockSetup {
     /// The system oscillator configuration
     pub oscillator: Oscillator,
-    // Make this type uncreatable
-    _0: (),
 }
 
 /// Selects the system oscillator source
@@ -725,10 +723,9 @@ pub trait SysctlExt {
 impl SysctlExt for tm4c123x::SYSCTL {
     fn constrain(self) -> Sysctl {
         Sysctl {
-            power_control: PowerControl { _0: () },
+            power_control: PowerControl {},
             clock_setup: ClockSetup {
                 oscillator: Oscillator::PrecisionInternal(SystemClock::UseOscillator(Divider::_1)),
-                _0: (),
             },
         }
     }

--- a/tm4c123x-hal/src/timer.rs
+++ b/tm4c123x-hal/src/timer.rs
@@ -4,7 +4,6 @@ use crate::{
     hal::timer::{CountDown, Periodic},
     sysctl::{self, Clocks},
 };
-use nb;
 
 #[rustfmt::skip]
 use tm4c123x::{
@@ -103,7 +102,7 @@ macro_rules! hal {
                     tim.tamr.write(|w| w.tamr().period());
 
                     let mut timer = Timer {
-                        tim:tim,
+                        tim,
                         clocks: *clocks,
                         timeout: Hertz(0),
                     };

--- a/tm4c129x-hal/src/hib.rs
+++ b/tm4c129x-hal/src/hib.rs
@@ -71,6 +71,6 @@ impl Hib {
         let subsec: u64 = subsec.into();
 
         let millis: u64 = subsec * 1000 / 32_768;
-        return seconds * 1000 + millis;
+        seconds * 1000 + millis
     }
 }

--- a/tm4c129x-hal/src/serial.rs
+++ b/tm4c129x-hal/src/serial.rs
@@ -1,5 +1,8 @@
 //! Serial
 
+// uart_hal_macro can be called with too-many arguments
+#![allow(clippy::too_many_arguments)]
+
 use core::{fmt, marker::PhantomData};
 
 use crate::{

--- a/tm4c129x-hal/src/sysctl.rs
+++ b/tm4c129x-hal/src/sysctl.rs
@@ -39,16 +39,14 @@ pub struct Sysctl {
 }
 
 /// Used to gate access to the run-time power control features of the chip.
-pub struct PowerControl {
-    _0: (),
-}
+#[non_exhaustive]
+pub struct PowerControl {}
 
 /// Used to configure the clock generators.
+#[non_exhaustive]
 pub struct ClockSetup {
     /// The system oscillator configuration
     pub oscillator: Oscillator,
-    // Make this type uncreatable
-    _0: (),
 }
 
 /// Selects the system oscillator source
@@ -746,10 +744,9 @@ pub trait SysctlExt {
 impl SysctlExt for tm4c129x::SYSCTL {
     fn constrain(self) -> Sysctl {
         Sysctl {
-            power_control: PowerControl { _0: () },
+            power_control: PowerControl {},
             clock_setup: ClockSetup {
                 oscillator: Oscillator::PrecisionInternal(SystemClock::UseOscillator(Divider::_1)),
-                _0: (),
             },
         }
     }


### PR DESCRIPTION
Mainly fix for:
- missing #Safety doc for pub unsafe fn
- manual non-exhaustive patterns