### PR TITLE
Update PAC crates dependencies

### DIFF
--- a/tm4c123x-hal/Cargo.toml
+++ b/tm4c123x-hal/Cargo.toml
@@ -29,7 +29,10 @@ features = ["unproven"]
 version = "1"
 
 [dependencies.tm4c123x]
-version = "0.9"
+## m-labs does not plan on publishing new release on crates.io and suggest to
+## use git instead with specific revision instead.
+git = "https://github.com/m-labs/dslite2svd.git"
+rev = "30145706b658136c35c90290701de3f02a4b8ef2"
 
 [dependencies.void]
 version = "1.0"

--- a/tm4c129x-hal/Cargo.toml
+++ b/tm4c129x-hal/Cargo.toml
@@ -17,7 +17,12 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.6"
 nb = "1"
-tm4c129x = "0.9"
+
+[dependencies.tm4c129x]
+## m-labs does not plan on publishing new release on crates.io and suggest to
+## use git instead with specific revision instead.
+git = "https://github.com/m-labs/dslite2svd.git"
+rev = "30145706b658136c35c90290701de3f02a4b8ef2"
 
 [dependencies.cast]
 version = "0.2"


### PR DESCRIPTION
m-labs (owner of PAC crates) does not plan on publishing new version on
crates.io and suggests using git instead.
See:
https://github.com/m-labs/dslite2svd/issues/13

Until a better solution is found, this patch uses latest version of crates.