### PR TITLE
fix openocd.cfg of tiva-c-launchpad example

### DIFF
--- a/examples/tiva-c-launchpad/openocd.cfg
+++ b/examples/tiva-c-launchpad/openocd.cfg
@@ -1,4 +1,4 @@
 # Sample OpenOCD configuration for the Tiva-C Launchpad development board
 
-source [find board/ek-tm4c124gxl.cfg]
+source [find board/ti_ek-tm4c123gxl.cfg]
 


### PR DESCRIPTION
`openocd` complained that it couldn't find the `ek-tm4c124gxl.cfg`. So, I was wondering if this should rather be `ek-tm4c123gxl`? When changing that it worked but a warning indicated that `ek-tm4c123gxl` was deprecated and `ti_ek-tm4c123gxl.cfg` should be used instead. That works.