### PR TITLE
Updated deps

### DIFF
--- a/examples/tiva-c-connected-launchpad/Cargo.toml
+++ b/examples/tiva-c-connected-launchpad/Cargo.toml
@@ -8,9 +8,9 @@ name = "tiva-c-connected-launchpad"
 version = "0.1.0"
 
 [dependencies]
-cortex-m = "0.6"
-cortex-m-rt = "0.6"
-cortex-m-semihosting = "0.3.2"
+cortex-m = "0.7"
+cortex-m-rt = "0.7"
+cortex-m-semihosting = "0.5"
 panic-halt = "0.2.0"
 
 [dependencies.tm4c129x-hal]

--- a/examples/tiva-c-launchpad/Cargo.toml
+++ b/examples/tiva-c-launchpad/Cargo.toml
@@ -8,9 +8,9 @@ name = "tiva-c-launchpad"
 version = "0.1.0"
 
 [dependencies]
-cortex-m = "0.6"
-cortex-m-rt = "0.6"
-cortex-m-semihosting = "0.3.2"
+cortex-m = "0.7"
+cortex-m-rt = "0.7"
+cortex-m-semihosting = "0.5"
 panic-halt = "0.2.0"
 
 [dependencies.tm4c123x-hal]

--- a/tm4c-hal/Cargo.toml
+++ b/tm4c-hal/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/rust-embedded-community/tm4c-hal"
 documentation = "https://docs.rs/tm4c-hal"
 
 [dependencies]
-cortex-m = "0.6"
+cortex-m = "0.7"
 nb = "1"
 
 [dependencies.embedded-hal]

--- a/tm4c-hal/README.md
+++ b/tm4c-hal/README.md
@@ -7,6 +7,11 @@ depending on your processor.
 
 ## Changelog
 
+* Updated dependencies in tm4c123x, tm4c129x, tm4c123x-hal, and
+tm4c129x-hal to use newer version of cortex-m (up to v0.7 as of this release).
+
+### Unreleased Changes ([Source](https://github.com/rust-embedded-community/tm4c-hal/tree/master/tm4c-hal) [Diff](https://github.com/rust-embedded-community/tm4c-hal/compare/tm4c-hal-0.4.1...master))
+
 * Basic EEPROM Read, Write, Erase added
 
 ### Unreleased Changes ([Source](https://github.com/rust-embedded-community/tm4c-hal/tree/master/tm4c-hal) [Diff](https://github.com/rust-embedded-community/tm4c-hal/compare/tm4c-hal-0.4.1...master))

--- a/tm4c123x-hal/Cargo.toml
+++ b/tm4c123x-hal/Cargo.toml
@@ -30,6 +30,7 @@ version = "1"
 
 [dependencies.tm4c123x]
 git = "https://github.com/m-labs/dslite2svd"
+tag = "v0.9.1"
 
 [dependencies.void]
 version = "1.0"

--- a/tm4c123x-hal/Cargo.toml
+++ b/tm4c123x-hal/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.2.2"
 default-features = false
 
 [dependencies.cortex-m]
-version = "0.6"
+version = "0.7"
 
 [dependencies.embedded-hal]
 version = "0.2.2"
@@ -29,7 +29,7 @@ features = ["unproven"]
 version = "1"
 
 [dependencies.tm4c123x]
-version = "0.9"
+git = "https://github.com/m-labs/dslite2svd"
 
 [dependencies.void]
 version = "1.0"

--- a/tm4c123x-hal/Cargo.toml
+++ b/tm4c123x-hal/Cargo.toml
@@ -29,8 +29,7 @@ features = ["unproven"]
 version = "1"
 
 [dependencies.tm4c123x]
-git = "https://github.com/m-labs/dslite2svd"
-tag = "v0.9.1"
+version = "0.9.1"
 
 [dependencies.void]
 version = "1.0"

--- a/tm4c123x-hal/Cargo.toml
+++ b/tm4c123x-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tm4c123x-hal"
-version = "0.10.2"
+version = "0.10.3"
 authors = [
 	"Jorge Aparicio <jorge@japaric.io>",
 	"Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",

--- a/tm4c123x-hal/README.md
+++ b/tm4c123x-hal/README.md
@@ -14,7 +14,7 @@ versions of RTIC and has been tested in hardware (Launchpad and custom PCB)
 using RTIC 1.1.4. Testing included SPI, ADC, Timers, EEPROM, GPIO, UART, 
 and multiple interrupts (UART, GPIO, TIMERS, ADC).
 
-### Unreleased Changes ([Source](https://github.com/rust-embedded-community/tm4c-hal/tree/master/tm4c123x-hal) [Diff](https://github.com/rust-embedded-community/tm4c-hal/compare/tm4c123x-hal-0.10.2...master))
+### Unreleased Changes ([Source](https://github.com/rust-embedded-community/tm4c-hal/tree/master/tm4c123x-hal) [Diff](https://github.com/rust-embedded-community/tm4c-hal/compare/tm4c123x-hal-0.10.3...master))
 
 * Use sealed traits for `*Pin` marker traits
 * Do not reexport `tm4c-hal` macros

--- a/tm4c123x-hal/README.md
+++ b/tm4c123x-hal/README.md
@@ -8,6 +8,12 @@
 
 ## Changelog
 
+* Update 0.10.3 - Updated the dependencies for the supporting crate tm4c123x to 
+0.9.1 which supports newer version of cortex-m. Version 0.10.3 can be used with newer
+versions of RTIC and has been tested in hardware (Launchpad and custom PCB) 
+using RTIC 1.1.4. Testing included SPI, ADC, Timers, EEPROM, GPIO, UART, 
+and multiple interrupts (UART, GPIO, TIMERS, ADC).
+
 ### Unreleased Changes ([Source](https://github.com/rust-embedded-community/tm4c-hal/tree/master/tm4c123x-hal) [Diff](https://github.com/rust-embedded-community/tm4c-hal/compare/tm4c123x-hal-0.10.2...master))
 
 * Use sealed traits for `*Pin` marker traits

--- a/tm4c129x-hal/Cargo.toml
+++ b/tm4c129x-hal/Cargo.toml
@@ -15,9 +15,11 @@ repository = "https://github.com/rust-embedded-community/tm4c-hal/tm4c129x-hal"
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.6"
+cortex-m = "0.7"
 nb = "1"
-tm4c129x = "0.9"
+
+[dependencies.tm4c129x]
+git = "https://github.com/m-labs/dslite2svd"
 
 [dependencies.cast]
 version = "0.2"

--- a/tm4c129x-hal/Cargo.toml
+++ b/tm4c129x-hal/Cargo.toml
@@ -20,6 +20,7 @@ nb = "1"
 
 [dependencies.tm4c129x]
 git = "https://github.com/m-labs/dslite2svd"
+tag = "v0.9.1"
 
 [dependencies.cast]
 version = "0.2"

--- a/tm4c129x-hal/Cargo.toml
+++ b/tm4c129x-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tm4c129x-hal"
-version = "0.9.2"
+version = "0.9.3"
 authors = [
 	"Jorge Aparicio <jorge@japaric.io>",
 	"Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",

--- a/tm4c129x-hal/Cargo.toml
+++ b/tm4c129x-hal/Cargo.toml
@@ -19,8 +19,7 @@ cortex-m = "0.7"
 nb = "1"
 
 [dependencies.tm4c129x]
-git = "https://github.com/m-labs/dslite2svd"
-tag = "v0.9.1"
+version = "0.9.1"
 
 [dependencies.cast]
 version = "0.2"

--- a/tm4c129x-hal/README.md
+++ b/tm4c129x-hal/README.md
@@ -13,7 +13,7 @@
 newer version of RTIC / cortex-m, however, unlike the tm4c123 this hasn't been 
 tested.
 
-### Unreleased Changes ([Source](https://github.com/rust-embedded-community/tm4c-hal/tree/master/tm4c129x-hal) [Diff](https://github.com/rust-embedded-community/tm4c-hal/compare/tm4c129x-hal-0.9.2...master))
+### Unreleased Changes ([Source](https://github.com/rust-embedded-community/tm4c-hal/tree/master/tm4c129x-hal) [Diff](https://github.com/rust-embedded-community/tm4c-hal/compare/tm4c129x-hal-0.9.3...master))
 
 * Use sealed traits for `*Pin` marker traits
 * Do not reexport `tm4c-hal` macros

--- a/tm4c129x-hal/README.md
+++ b/tm4c129x-hal/README.md
@@ -8,6 +8,11 @@
 
 ## Changelog
 
+* Update 0.9.3 - Updated the dependencies for the supporting crate tm4c129x to 
+0.9.1 which supports newer version of cortex-m. This _should_ allow for running
+newer version of RTIC / cortex-m, however, unlike the tm4c123 this hasn't been 
+tested.
+
 ### Unreleased Changes ([Source](https://github.com/rust-embedded-community/tm4c-hal/tree/master/tm4c129x-hal) [Diff](https://github.com/rust-embedded-community/tm4c-hal/compare/tm4c129x-hal-0.9.2...master))
 
 * Use sealed traits for `*Pin` marker traits


### PR DESCRIPTION
Howdy,

I'd like to submit for review some changes to the Cargo.toml files to upgrade the dependencies to use with more modern dependencies, such as RTIC v1. We recently started a project in RTIC v1 for the Max32660 and I wanted to upgrade an older TM4C project that used RTIC v0.5.

To do this, I had to change some of the code in the [dslite2svd crate](https://github.com/m-labs/dslite2svd) in commit [#77a40f0](https://github.com/m-labs/dslite2svd/commit/77a40f0694012db8e7bbfec35f8833da538c3d5f). I was hoping to get this version released on [crates.io](https://crates.io/) but after [discussing with the maintainer](https://github.com/m-labs/dslite2svd/issues/18) they tagged the repo as v0.9.1 and we agreed to try and submit a PR to this project using the git repo + tag instead of trying to update crates.io for the tm4c123x and tm4c129x dependencies.

I've been using the upgraded HAL with RTIC v1 and haven't noticed any issues with GPIO, EEPROM, UART, Timers, ADC, and SPI. The project has been behaving similarly to 

Thanks for considering!

